### PR TITLE
ci: use macos-15; use actions/upload-artifact@v5; use cmake>3.5.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         qt_version: [5.14.2]
-        platform: [ubuntu-22.04, macos-13, windows-2022]
+        platform: [ubuntu-22.04, macos-14, windows-2022]
         arch: [x86, x64]
         include:
           - platform: windows-2022
@@ -23,7 +23,7 @@ jobs:
         exclude:
           - platform: ubuntu-22.04
             arch: x86
-          - platform: macos-13
+          - platform: macos-14
             arch: x86
       fail-fast: false
     runs-on: ${{ matrix.platform }}
@@ -129,7 +129,7 @@ jobs:
           mv ./Notepanda*.AppImage ./Notepanda.AppImage
       - name: Linux - ${{ matrix.qt_version }} - Uploading artifact
         if: startsWith(matrix.platform, 'ubuntu')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: Notepanda-${{ github.sha }}.Linux-${{ matrix.arch }}.qt${{ matrix.qt_version }}.AppImage
           path: build/Notepanda.AppImage
@@ -199,7 +199,7 @@ jobs:
           pathTarget: ./release.7z
       - name: Win - ${{ matrix.arch }} - ${{ matrix.qt_version }} - Uploading artifact
         if: startsWith(matrix.platform, 'windows')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: Notepanda-${{ github.sha }}.Windows-${{ matrix.arch }}.qt${{ matrix.qt_version }}.7z
           path: release.7z
@@ -244,7 +244,7 @@ jobs:
           macdeployqt notepanda.app -dmg
       - name: macOS - ${{ matrix.qt_version }} - Uploading Artifact
         if: startsWith(matrix.platform, 'macos')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: Notepanda-${{ github.sha }}.macOS-${{ matrix.arch }}.qt${{ matrix.qt_version }}.dmg
           path: build/notepanda.dmg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         qt_version: [5.14.2]
-        platform: [ubuntu-22.04, macos-14-large, windows-2022]
+        platform: [ubuntu-22.04, macos-15-intel, windows-2022]
         arch: [x86, x64]
         include:
           - platform: windows-2022
@@ -23,7 +23,7 @@ jobs:
         exclude:
           - platform: ubuntu-22.04
             arch: x86
-          - platform: macos-14-large
+          - platform: macos-15-intel
             arch: x86
       fail-fast: false
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         qt_version: [5.14.2]
-        platform: [ubuntu-22.04, macos-14, windows-2022]
+        platform: [ubuntu-22.04, macos-14-large, windows-2022]
         arch: [x86, x64]
         include:
           - platform: windows-2022
@@ -23,7 +23,7 @@ jobs:
         exclude:
           - platform: ubuntu-22.04
             arch: x86
-          - platform: macos-14
+          - platform: macos-14-large
             arch: x86
       fail-fast: false
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/cpack-deb.yml
+++ b/.github/workflows/cpack-deb.yml
@@ -65,7 +65,7 @@ jobs:
         shell: bash
         run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> "$GITHUB_OUTPUT"
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ steps.get_package.outputs.NAME }}
           path: build/${{ steps.get_package.outputs.NAME }}

--- a/.github/workflows/cpack-nsis.yml
+++ b/.github/workflows/cpack-nsis.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           echo "NAME=$(basename build/Notepanda-*.exe)" >> "$GITHUB_OUTPUT"
       - name: Win-${{ matrix.arch }} - ${{ matrix.qt_version }} - uploading artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ steps.get_package.outputs.NAME }}
           path: build/${{ steps.get_package.outputs.NAME }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeLists.txt
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.5.0)
 
 file(STRINGS "${CMAKE_SOURCE_DIR}/makespec/VERSION" VERSION)
 file(STRINGS "${CMAKE_SOURCE_DIR}/makespec/BUILDVERSION" BUILD_VERSION)


### PR DESCRIPTION
- Compatibility with CMake < 3.5 has been removed from CMake.
- https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/